### PR TITLE
firestoreの関数追加

### DIFF
--- a/src/api/addWordEmotions.ts
+++ b/src/api/addWordEmotions.ts
@@ -1,0 +1,28 @@
+import { addDoc, collection, doc } from 'firebase/firestore';
+import { EmotionDataType } from '../types/EmotionDataType';
+import { db } from '../lib/firebase';
+import { COLLECTIONNAME, EmotionDataDBType } from '../lib/firestore';
+
+type Props = {
+  text: string;
+  emotionData: EmotionDataType;
+};
+
+/**
+ * 文字列に対応する感情をfireStoreに追加する関数
+ *
+ * @param text 文字列
+ * @param emotionData 対応するEmotionData
+ *
+ * @see
+ * https://firebase.google.com/docs/firestore/manage-data/add-data?hl=ja
+ */
+export const addWordEmotions = async ({ text, emotionData }: Props) => {
+  const collectionRef = collection(db, COLLECTIONNAME);
+  const docData: EmotionDataDBType = {
+    documentWord: text,
+    emotionData: emotionData,
+  };
+
+  await addDoc(collectionRef, docData);
+};

--- a/src/api/addWordEmotions.ts
+++ b/src/api/addWordEmotions.ts
@@ -1,4 +1,4 @@
-import { addDoc, collection, doc } from 'firebase/firestore';
+import { addDoc, collection } from 'firebase/firestore';
 import { EmotionDataType } from '../types/EmotionDataType';
 import { db } from '../lib/firebase';
 import { COLLECTIONNAME, EmotionDataDBType } from '../lib/firestore';

--- a/src/api/getWordEmotions.ts
+++ b/src/api/getWordEmotions.ts
@@ -1,0 +1,28 @@
+import { collection, getDocs, query, where } from 'firebase/firestore';
+import { EmotionDataType } from '../types/EmotionDataType';
+import { db } from '../lib/firebase';
+import { COLLECTIONNAME, FIELDNAME } from '../lib/firestore';
+
+/**
+ * 文字列・対応する感情をfireStoreから取得する関数
+ *
+ * @param text 文字列
+ *
+ * @returns emotionData 対応するEmotionData | 文字列が存在しない場合には空のEmotionData
+ *
+ * @see
+ * https://firebase.google.com/docs/firestore/query-data/get-data?hl=ja
+ */
+export const getWordEmotions = async (text: string): Promise<EmotionDataType> => {
+  const collectionRef = collection(db, COLLECTIONNAME);
+  const queryResult = query(collectionRef, where(FIELDNAME, '==', text));
+
+  const docList = await getDocs(queryResult);
+
+  /**
+   * 文字列が存在しない場合には空のEmotionDataを返す
+   */
+  if (docList.size === 0) return {} as EmotionDataType;
+
+  return docList.docs[0].data().emotionData as EmotionDataType;
+};

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -1,0 +1,23 @@
+import { EmotionDataType } from '../types/EmotionDataType';
+
+/**
+ * FireStore DB設計
+ *
+ * コレクション名: words
+ * ドキュメント: 自動設定の文字列
+ *
+ * フィールド名: documentWord: string 対象の文字列
+ * フィールド名: emotionData: EmotionDataType 対応する感情
+ */
+
+// DBの型定義
+export type EmotionDataDBType = {
+  documentWord: string;
+  emotionData: EmotionDataType;
+};
+
+// コレクションの名前
+export const COLLECTIONNAME = 'words';
+
+// 文字列を格納するフィールド名
+export const FIELDNAME = 'documentWord';


### PR DESCRIPTION
## 概要
- firestoreとの接続用の関数を追加
  - 単語に対応する感情データを呼び出す関数
  - 単語と対応する感情データを保存する関数

データ設計はこんな感じ
<img width="1348" alt="image" src="https://github.com/nkc-ug/yagi5108/assets/109256327/3f684b8c-aed3-4d9c-9402-be714c95be4b">


## 連絡事項
@Mount-Book 
getの方に関しては、非同期関数として必ず await をつけて呼び出す👌